### PR TITLE
Fix compiler warnings

### DIFF
--- a/drivers/linux-driver/src/inc/common.h
+++ b/drivers/linux-driver/src/inc/common.h
@@ -22,6 +22,7 @@
 #include <linux/slab.h>
 #include <linux/errno.h>
 #include <linux/mutex.h>
+#include <linux/sched.h>
 #include <asm/uaccess.h>
 #include <linux/usb.h>
 #include <linux/list.h>

--- a/drivers/linux-driver/src/usbhandlers.c
+++ b/drivers/linux-driver/src/usbhandlers.c
@@ -932,7 +932,7 @@ static int _on_alloc_disp_tickets_pool(struct rpusbdisp_dev * dev)
     dev->disp_tickets_pool.disp_urb_count = actual_allocated;
     dev->disp_tickets_pool.availiable_count = actual_allocated;
     dev->disp_tickets_pool.packet_size_factor = packet_size_factor;
-    dev_info(&dev->interface->dev, "allocated %d urb tickets for transfering display data. %lu size each\n", actual_allocated, ticket_logic_size);
+    dev_info(&dev->interface->dev, "allocated %d urb tickets for transfering display data. %zu size each\n", actual_allocated, ticket_logic_size);
 
     return actual_allocated?0:-ENOMEM;
 };

--- a/drivers/linux-driver/src/usbhandlers.c
+++ b/drivers/linux-driver/src/usbhandlers.c
@@ -494,7 +494,7 @@ static int _bitblt_encoder_init(struct bitblt_encoding_context_t * ctx, struct r
     
     if ( required_tickets_count>RPUSBDISP_MAX_TRANSFER_TICKETS_COUNT)
     {
-        err("required_tickets_count (%d)>RPUSBDISP_MAX_TRANSFER_TICKETS_COUNT(%d)\n", required_tickets_count, RPUSBDISP_MAX_TRANSFER_TICKETS_COUNT);
+        err("required_tickets_count (%zu)>RPUSBDISP_MAX_TRANSFER_TICKETS_COUNT(%d)\n", required_tickets_count, RPUSBDISP_MAX_TRANSFER_TICKETS_COUNT);
        // BUG_ON(1);
         return 0;
     }


### PR DESCRIPTION
Fixes compiler warnings at least up through gcc version 6.2 and kernel version 3.18.44.